### PR TITLE
Update to v14.6.1 of ilib

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-es6",
-    "version": "14.6.0",
+    "version": "14.6.1",
     "main": "./lib/index.js",
     "main-es6": "./src/index.js",
     "description": "ES6 wrappers around iLib classes",
@@ -52,7 +52,7 @@
         "clean": "git clean -f -d * ; rm -rf lib"
     },
     "dependencies": {
-        "ilib": "14.6.0",
+        "ilib": "14.6.1",
         "promise": "^8.1.0"
     },
     "devDependencies": {


### PR DESCRIPTION
Update to v14.6.1 of ilib. Each version of ilib-es6 should correspond to the same version of ilib, so we have to publish this one first, then 14.6.2, then 14.7.0.